### PR TITLE
DTSPO-5692 Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hmcts/platform-operations


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/DTSPO-5692


### Change description ###
Add platform operations team as code owners


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
